### PR TITLE
chore: switch to `@node-ipc/js-queue`

### DIFF
--- a/dao/client.js
+++ b/dao/client.js
@@ -3,7 +3,7 @@ import tls from 'tls';
 import EventParser from '../entities/EventParser.js';
 import Message from 'js-message';
 import fs from 'fs';
-import Queue from 'js-queue';
+import Queue from '@node-ipc/js-queue';
 import Events from 'event-pubsub';
 
 let eventParser = new EventParser();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@achrinza/node-ipc",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@achrinza/node-ipc",
-      "version": "10.1.1",
+      "version": "10.1.2",
       "license": "MIT",
       "dependencies": {
+        "@node-ipc/js-queue": "2.0.3",
         "event-pubsub": "5.0.3",
         "js-message": "1.0.7",
-        "js-queue": "2.0.2",
         "strong-type": "^1.0.1"
       },
       "devDependencies": {
@@ -75,6 +75,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@node-ipc/js-queue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@node-ipc/js-queue/-/js-queue-2.0.3.tgz",
+      "integrity": "sha512-fL1wpr8hhD5gT2dA1qifeVaoDFlQR5es8tFuKqjHX+kdOtdNHnxkVZbtIrR2rxnMFvehkjaZRNV2H/gPXlb0hw==",
+      "dependencies": {
+        "easy-stack": "1.0.1"
+      },
+      "engines": {
+        "node": ">=1.0.0"
       }
     },
     "node_modules/@node-ipc/vanilla-test": {
@@ -623,17 +634,6 @@
       "integrity": "sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA==",
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/js-queue": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.2.tgz",
-      "integrity": "sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==",
-      "dependencies": {
-        "easy-stack": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=1.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -1267,6 +1267,14 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@node-ipc/js-queue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@node-ipc/js-queue/-/js-queue-2.0.3.tgz",
+      "integrity": "sha512-fL1wpr8hhD5gT2dA1qifeVaoDFlQR5es8tFuKqjHX+kdOtdNHnxkVZbtIrR2rxnMFvehkjaZRNV2H/gPXlb0hw==",
+      "requires": {
+        "easy-stack": "1.0.1"
+      }
+    },
     "@node-ipc/vanilla-test": {
       "version": "1.4.9",
       "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.9.tgz",
@@ -1691,14 +1699,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.7.tgz",
       "integrity": "sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA=="
-    },
-    "js-queue": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.2.tgz",
-      "integrity": "sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==",
-      "requires": {
-        "easy-stack": "^1.0.1"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "event-pubsub": "5.0.3",
     "js-message": "1.0.7",
-    "js-queue": "2.0.2",
+    "@node-ipc/js-queue": "2.0.3",
     "strong-type": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This removes a transitive nested dependency that's managed by
@/riaevangelist (The original author of `node-ipc`) - `easy-stack@^1.0.1`.

Changes in `@node-ipc/js-queue` compared to upstream: https://github.com/node-ipc/js-queue/compare/78b31b864b2b9db931911d605c1f68efecdd3b63...a699ff0d6e51590ccf567e2ae514ff346f9fe8a5

see: https://github.com/node-ipc/node-ipc/issues/2

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>