### PR TITLE
chore: switch to `@node-ipc/js-queue`

### DIFF
--- a/dao/client.js
+++ b/dao/client.js
@@ -5,7 +5,7 @@ const net = require('net'),
     EventParser = require('../entities/EventParser.js'),
     Message = require('js-message'),
     fs = require('fs'),
-    Queue = require('js-queue'),
+    Queue = require('@node-ipc/js-queue'),
     Events = require('event-pubsub');
 
 let eventParser = new EventParser();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "9.2.1",
       "license": "MIT",
       "dependencies": {
+        "@node-ipc/js-queue": "2.0.3",
         "event-pubsub": "4.3.0",
-        "js-message": "1.0.7",
-        "js-queue": "2.0.2"
+        "js-message": "1.0.7"
       },
       "devDependencies": {
         "codacy-coverage": "2.0.0",
@@ -104,6 +104,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@node-ipc/js-queue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@node-ipc/js-queue/-/js-queue-2.0.3.tgz",
+      "integrity": "sha512-fL1wpr8hhD5gT2dA1qifeVaoDFlQR5es8tFuKqjHX+kdOtdNHnxkVZbtIrR2rxnMFvehkjaZRNV2H/gPXlb0hw==",
+      "dependencies": {
+        "easy-stack": "1.0.1"
+      },
+      "engines": {
+        "node": ">=1.0.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -1061,17 +1072,6 @@
       "integrity": "sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA==",
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/js-queue": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.2.tgz",
-      "integrity": "sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==",
-      "dependencies": {
-        "easy-stack": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=1.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -2141,6 +2141,14 @@
         }
       }
     },
+    "@node-ipc/js-queue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@node-ipc/js-queue/-/js-queue-2.0.3.tgz",
+      "integrity": "sha512-fL1wpr8hhD5gT2dA1qifeVaoDFlQR5es8tFuKqjHX+kdOtdNHnxkVZbtIrR2rxnMFvehkjaZRNV2H/gPXlb0hw==",
+      "requires": {
+        "easy-stack": "1.0.1"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -2898,14 +2906,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.7.tgz",
       "integrity": "sha512-efJLHhLjIyKRewNS9EGZ4UpI8NguuL6fKkhRxVuMmrGV2xN/0APGdQYwLFky5w9naebSZ0OwAGp0G6/2Cg90rA=="
-    },
-    "js-queue": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.2.tgz",
-      "integrity": "sha512-pbKLsbCfi7kriM3s1J4DDCo7jQkI58zPLHi0heXPzPlj0hjUsm+FesPUbE0DSbIVIK503A36aUBoCN7eMFedkA==",
-      "requires": {
-        "easy-stack": "^1.0.1"
-      }
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "event-pubsub": "4.3.0",
     "js-message": "1.0.7",
-    "js-queue": "2.0.2"
+    "@node-ipc/js-queue": "2.0.3"
   },
   "devDependencies": {
     "codacy-coverage": "2.0.0",


### PR DESCRIPTION
This removes a transitive nested dependency that's managed by
@/riaevangelist (The original author of `node-ipc`) - `easy-stack@^1.0.1`.

see: https://github.com/node-ipc/node-ipc/issues/2

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>