### PR TITLE
Update node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@achrinza/node-ipc",
-  "version": "10.1.4",
+  "version": "10.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@achrinza/node-ipc",
-      "version": "10.1.4",
+      "version": "10.1.5",
       "license": "MIT",
       "dependencies": {
         "@achrinza/event-pubsub": "5.0.6",
@@ -24,7 +24,7 @@
         "node-http-server": "^8.1.4"
       },
       "engines": {
-        "node": "14 || 16 || 17"
+        "node": "14 || 16 || 17 || 18"
       }
     },
     "node_modules/@achrinza/event-pubsub": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "14 || 16 || 17"
+    "node": "14 || 16 || 17 || 18"
   },
   "dependencies": {
     "@achrinza/event-pubsub": "5.0.6",


### PR DESCRIPTION
Node 18 is out. ``vue create`` depends on this library somehow and chokes on node 18.

```bash
error @achrinza/node-ipc@9.2.2: The engine "node" is incompatible with this module. Expected version "8 || 10 || 12 || 14 || 16 || 17". Got "18.0.0"
error Found incompatible module.
```

I ran `npm test` with node 18 and the tests seem to pass. You might have to release a patch release after this.

```bash
node --version
v18.0.0
```