### PR TITLE
chore: Fix support for Node.js 18 with yarn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@achrinza/node-ipc",
-  "version": "10.1.4",
+  "version": "10.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@achrinza/node-ipc",
-      "version": "10.1.4",
+      "version": "10.1.6",
       "license": "MIT",
       "dependencies": {
-        "@achrinza/event-pubsub": "5.0.6",
+        "@achrinza/event-pubsub": "https://github.com/achrinza/event-pubsub#4d0a3e3",
         "@node-ipc/js-queue": "2.0.3",
         "js-message": "1.0.7",
         "strong-type": "1.0.1"
@@ -24,26 +24,26 @@
         "node-http-server": "^8.1.4"
       },
       "engines": {
-        "node": "14 || 16 || 17"
+        "node": "14 || 16 || 17 || 18"
       }
     },
     "node_modules/@achrinza/event-pubsub": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@achrinza/event-pubsub/-/event-pubsub-5.0.6.tgz",
-      "integrity": "sha512-MIS4ZMmby1naDswZ/aRgVvIh/ZdocJ7GFp7ZEDIHLfWiHV2kbmfaSMPFmV4INmKk0fl8Oc+qeBtT1XIXdYZFag==",
+      "version": "5.0.7",
+      "resolved": "git+ssh://git@github.com/achrinza/event-pubsub.git#4d0a3e3dd38f95d438fa2506ebb5bf3e26a9201a",
+      "license": "MIT",
       "dependencies": {
-        "@achrinza/strong-type": "0.1.7"
+        "@achrinza/strong-type": "0.1.8"
       },
       "engines": {
-        "node": "13 || 14 || 16 || 17"
+        "node": "13 || 14 || 16 || 17 || 18"
       }
     },
     "node_modules/@achrinza/strong-type": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.7.tgz",
-      "integrity": "sha512-RX2ntDMRYUiTlGl+0RE7R6FSrM+Wq+uZzAMWK/G7JQ1VA2+DifcMA4Y3U5tHcnwCmmawNtRQuuHbQZSlOcbNpA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.8.tgz",
+      "integrity": "sha512-yL/NlZbL6S+pQn7+b6eFAIzqyS9uXYZcSGsdQx/H8j8GRkszWGHmsgS41WT9Si/JyzXuJi7ieHqyWw5YIwrBTA==",
       "engines": {
-        "node": "12 || 13 || 14 || 15 || 16 || 17"
+        "node": "12 || 13 || 14 || 15 || 16 || 17 || 18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1140,17 +1140,16 @@
   },
   "dependencies": {
     "@achrinza/event-pubsub": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@achrinza/event-pubsub/-/event-pubsub-5.0.6.tgz",
-      "integrity": "sha512-MIS4ZMmby1naDswZ/aRgVvIh/ZdocJ7GFp7ZEDIHLfWiHV2kbmfaSMPFmV4INmKk0fl8Oc+qeBtT1XIXdYZFag==",
+      "version": "git+ssh://git@github.com/achrinza/event-pubsub.git#4d0a3e3dd38f95d438fa2506ebb5bf3e26a9201a",
+      "from": "@achrinza/event-pubsub@https://github.com/achrinza/event-pubsub#4d0a3e3",
       "requires": {
-        "@achrinza/strong-type": "0.1.7"
+        "@achrinza/strong-type": "0.1.8"
       }
     },
     "@achrinza/strong-type": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.7.tgz",
-      "integrity": "sha512-RX2ntDMRYUiTlGl+0RE7R6FSrM+Wq+uZzAMWK/G7JQ1VA2+DifcMA4Y3U5tHcnwCmmawNtRQuuHbQZSlOcbNpA=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.8.tgz",
+      "integrity": "sha512-yL/NlZbL6S+pQn7+b6eFAIzqyS9uXYZcSGsdQx/H8j8GRkszWGHmsgS41WT9Si/JyzXuJi7ieHqyWw5YIwrBTA=="
     },
     "@babel/code-frame": {
       "version": "7.16.7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node": "14 || 16 || 17 || 18"
   },
   "dependencies": {
-    "@achrinza/event-pubsub": "5.0.6",
+    "@achrinza/event-pubsub": "https://github.com/achrinza/event-pubsub#4d0a3e3",
     "js-message": "1.0.7",
     "@node-ipc/js-queue": "2.0.3",
     "strong-type": "1.0.1"


### PR DESCRIPTION
`yarn install` was failing with the following error:

```
error @achrinza/event-pubsub@5.0.6: The engine "node" is incompatible with this module. Expected version "13 || 14 || 16 || 17". Got "18.7.0"
error Found incompatible module.
```