### PR TITLE
build: add support for node 20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
           - 17
           - 18
           - 19
+          - 20
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "14 || 16 || 17 || 18 || 19"
+    "node": "14 || 16 || 17 || 18 || 19 || 20"
   },
   "dependencies": {
     "@achrinza/event-pubsub": "5.0.8",


### PR DESCRIPTION
# Description
This PR adds support for Node v20 by bumping the accepted engines and adding to the CI node versions to test.

# Steps to test
Let CI run; see it succeed.

# Notes
Feedback is appreciated; let me know if I missed anything required to add Node v20 support, I'm unsure if all the related deps have also bumped their supported Node versions yet.


Thank you for maintaining this package 🤗 .
