### PR TITLE
chore: support Node.js v20 engine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
           - 17
           - 18
           - 19
+          - 20
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "14 || 16 || 17 || 18 || 19"
+    "node": "14 || 16 || 17 || 18 || 19 || 20"
   },
   "dependencies": {
     "@achrinza/event-pubsub": "5.0.8",


### PR DESCRIPTION
closes: https://github.com/achrinza/node-ipc/issues/45