### PR TITLE
chore: support Node.js v21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,7 @@ jobs:
           - 18
           - 19
           - 20
+          - 21
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@achrinza/event-pubsub": "5.0.9",
+        "@achrinza/strong-type": "1.1.8",
         "@node-ipc/js-queue": "2.0.3",
-        "js-message": "1.0.7",
-        "strong-type": "1.0.1"
+        "js-message": "1.0.7"
       },
       "devDependencies": {
-        "@node-ipc/vanilla-test": "1.4.13",
+        "@node-ipc/vanilla-test": "1.4.14",
         "c8": "^7.7.3",
         "esbuild": "^0.12.28",
         "lcov2badge": "^0.1.2",
@@ -38,12 +38,20 @@
         "node": "13 || 14 || 16 || 17 || 18 || 19 || 20"
       }
     },
-    "node_modules/@achrinza/strong-type": {
+    "node_modules/@achrinza/event-pubsub/node_modules/@achrinza/strong-type": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.11.tgz",
       "integrity": "sha512-35Ou0jcGHGKQS8a6lgdan+u3BajmL315ZpDhH2/WSRNgG1jPpizhe87epgLaotN4uY3kXaEbfRU56sBPMdR5LA==",
       "engines": {
         "node": "12 || 13 || 14 || 15 || 16 || 17 || 18 || 19 || 20"
+      }
+    },
+    "node_modules/@achrinza/strong-type": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-1.1.8.tgz",
+      "integrity": "sha512-ub/mgPRjbqZmwhU3rGya745IMn9znh3cm4g2iGepzvzhZUlKhLRfdkVoUD+H1NLaHE30pRp/FQHEoHTAVcleBQ==",
+      "engines": {
+        "node": "^12.21.0 || 14 || 15 || 16 || 17 || 18 || 19 || 20 || 21"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -108,12 +116,12 @@
       }
     },
     "node_modules/@node-ipc/vanilla-test": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.13.tgz",
-      "integrity": "sha512-XBBSnmxjB0yLFJjj92PllIUlue3SCS1iF015xOYYLYHc7sPSS1mJVp66pDHazJX0WezAA3xf1YZFPh/5d+2q/A==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.14.tgz",
+      "integrity": "sha512-EYS95I5uT6zEJkupepGkNRbeF8IXC3CPhXqId4xGuaSxyC/Inv0OcC+9tnNp8IPkRCD2xi470AJnaOgTJlFhUg==",
       "dev": true,
       "dependencies": {
-        "@achrinza/strong-type": "1.1.5",
+        "@achrinza/strong-type": "1.1.7",
         "ansi-colors-es6": "5.0.0"
       },
       "engines": {
@@ -121,12 +129,12 @@
       }
     },
     "node_modules/@node-ipc/vanilla-test/node_modules/@achrinza/strong-type": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-1.1.5.tgz",
-      "integrity": "sha512-eSgjj9sdl2YJl/WOx/dnSXh3ntZCe0fLDhteGYJ1BeIACcwyl/y5HOEymciP0vtzxqxnfNpIL2phNd/upNeI3Q==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-1.1.7.tgz",
+      "integrity": "sha512-YYEeuzKbXiZcT8ANH9v1UlO/fgSpHO90GcF2D2xY5EIiUcyI3vOsrIzge5map09+ddoI8tkV4v7EKV1oIfikiw==",
       "dev": true,
       "engines": {
-        "node": "^12.21.0 || 14 || 15 || 16 || 17 || 18 || 19 || 20"
+        "node": "^12.21.0 || 14 || 15 || 16 || 17 || 18 || 19 || 20 || 21"
       }
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -994,14 +1002,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strong-type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strong-type/-/strong-type-1.0.1.tgz",
-      "integrity": "sha512-K8KEzne00nA5HG3eSIPy44adqGTAMnNlpfvRWtiv8QvRsRm0/rMLHtSoppJ11iFtnmzzpgeYogzdY2YMgrUgOA==",
-      "engines": {
-        "node": ">=12.21.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1145,12 +1145,19 @@
       "integrity": "sha512-49RyPP7w4abKMsLRHKgB9neAH085mdHQtv+0H5TnJeOq3oK57qQRd/JD9K5Z5D3vFODsvBODiBjYkRQZKdqiAA==",
       "requires": {
         "@achrinza/strong-type": "0.1.11"
+      },
+      "dependencies": {
+        "@achrinza/strong-type": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.11.tgz",
+          "integrity": "sha512-35Ou0jcGHGKQS8a6lgdan+u3BajmL315ZpDhH2/WSRNgG1jPpizhe87epgLaotN4uY3kXaEbfRU56sBPMdR5LA=="
+        }
       }
     },
     "@achrinza/strong-type": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-0.1.11.tgz",
-      "integrity": "sha512-35Ou0jcGHGKQS8a6lgdan+u3BajmL315ZpDhH2/WSRNgG1jPpizhe87epgLaotN4uY3kXaEbfRU56sBPMdR5LA=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-1.1.8.tgz",
+      "integrity": "sha512-ub/mgPRjbqZmwhU3rGya745IMn9znh3cm4g2iGepzvzhZUlKhLRfdkVoUD+H1NLaHE30pRp/FQHEoHTAVcleBQ=="
     },
     "@babel/code-frame": {
       "version": "7.16.7",
@@ -1199,19 +1206,19 @@
       }
     },
     "@node-ipc/vanilla-test": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.13.tgz",
-      "integrity": "sha512-XBBSnmxjB0yLFJjj92PllIUlue3SCS1iF015xOYYLYHc7sPSS1mJVp66pDHazJX0WezAA3xf1YZFPh/5d+2q/A==",
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@node-ipc/vanilla-test/-/vanilla-test-1.4.14.tgz",
+      "integrity": "sha512-EYS95I5uT6zEJkupepGkNRbeF8IXC3CPhXqId4xGuaSxyC/Inv0OcC+9tnNp8IPkRCD2xi470AJnaOgTJlFhUg==",
       "dev": true,
       "requires": {
-        "@achrinza/strong-type": "1.1.5",
+        "@achrinza/strong-type": "1.1.7",
         "ansi-colors-es6": "5.0.0"
       },
       "dependencies": {
         "@achrinza/strong-type": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-1.1.5.tgz",
-          "integrity": "sha512-eSgjj9sdl2YJl/WOx/dnSXh3ntZCe0fLDhteGYJ1BeIACcwyl/y5HOEymciP0vtzxqxnfNpIL2phNd/upNeI3Q==",
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/@achrinza/strong-type/-/strong-type-1.1.7.tgz",
+          "integrity": "sha512-YYEeuzKbXiZcT8ANH9v1UlO/fgSpHO90GcF2D2xY5EIiUcyI3vOsrIzge5map09+ddoI8tkV4v7EKV1oIfikiw==",
           "dev": true
         }
       }
@@ -1869,11 +1876,6 @@
       "requires": {
         "ansi-regex": "^5.0.1"
       }
-    },
-    "strong-type": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strong-type/-/strong-type-1.0.1.tgz",
-      "integrity": "sha512-K8KEzne00nA5HG3eSIPy44adqGTAMnNlpfvRWtiv8QvRsRm0/rMLHtSoppJ11iFtnmzzpgeYogzdY2YMgrUgOA=="
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
     "access": "public"
   },
   "engines": {
-    "node": "14 || 16 || 17 || 18 || 19 || 20"
+    "node": "14 || 16 || 17 || 18 || 19 || 20 || 21"
   },
   "dependencies": {
     "@achrinza/event-pubsub": "5.0.9",
+    "@achrinza/strong-type": "1.1.8",
     "@node-ipc/js-queue": "2.0.3",
-    "js-message": "1.0.7",
-    "strong-type": "1.0.1"
+    "js-message": "1.0.7"
   },
   "devDependencies": {
-    "@node-ipc/vanilla-test": "1.4.13",
+    "@node-ipc/vanilla-test": "1.4.14",
     "c8": "^7.7.3",
     "esbuild": "^0.12.28",
     "lcov2badge": "^0.1.2",

--- a/test/TCP/client.js
+++ b/test/TCP/client.js
@@ -1,5 +1,5 @@
 import VanillaTest from '@node-ipc/vanilla-test';
-import Is from 'strong-type';
+import Is from '@achrinza/strong-type';
 import {IPCModule}   from '../../node-ipc.js';
 import delay from '../../helpers/delay.js';
 

--- a/test/TCP/server.js
+++ b/test/TCP/server.js
@@ -1,5 +1,5 @@
 import VanillaTest from '@node-ipc/vanilla-test';
-import Is from 'strong-type';
+import Is from '@achrinza/strong-type';
 import {IPCModule}   from '../../node-ipc.js';
 import delay from '../../helpers/delay.js';
 

--- a/test/UDP/client.js
+++ b/test/UDP/client.js
@@ -1,5 +1,5 @@
 import VanillaTest from '@node-ipc/vanilla-test';
-import Is from 'strong-type';
+import Is from '@achrinza/strong-type';
 import {IPCModule}   from '../../node-ipc.js';
 import delay from '../../helpers/delay.js';
 

--- a/test/unix/client.js
+++ b/test/unix/client.js
@@ -1,5 +1,5 @@
 import VanillaTest from '@node-ipc/vanilla-test';
-import Is from 'strong-type';
+import Is from '@achrinza/strong-type';
 import {IPCModule}   from '../../node-ipc.js';
 import delay from '../../helpers/delay.js';
 


### PR DESCRIPTION
- Update to Node.js v21-compatible deps
- Test against Node.js v21
- Update `engines.node` for Node.js v21
- Switch to `@achrinza/strong-type` for prod dependency

see: https://github.com/achrinza/node-ipc/issues/54